### PR TITLE
Lower minSdk to 21 and use compat libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ captures/
 .idea/misc.xml
 # Comment next line if keeping position of elements in Navigation Editor is relevant for you
 .idea/navEditor.xml
+.idea/deploymentTargetDropDown.xml
 
 # Keystore files
 # Uncomment the following lines if you do not want to check your keystore files in.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.snad.kommutedemo"
-        minSdk 30
+        minSdk 26
         targetSdk 32
         versionCode 1
         versionName "1.0"

--- a/app/src/main/java/com/snad/kommutedemo/MainActivity.kt
+++ b/app/src/main/java/com/snad/kommutedemo/MainActivity.kt
@@ -16,6 +16,7 @@ import com.snad.kommute.Kommute
 import com.snad.kommutedemo.network.BitcoinApi
 import com.snad.kommutedemo.network.getRetrofit
 import com.snad.kommutedemo.ui.theme.KommuteTheme
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
@@ -40,7 +41,7 @@ class MainActivity : ComponentActivity() {
                        modifier = Modifier.align(Alignment.Center),
                        onClick = { loadBitcoinPrice() }
                    ) {
-                       Text(text = "Make api call")
+                       Text(text = "Do 3 api calls")
                    }
                 }
             }
@@ -49,6 +50,10 @@ class MainActivity : ComponentActivity() {
 
     private fun loadBitcoinPrice() {
         lifecycleScope.launch {
+            api.getBitcoinPrice()
+            delay(3000)
+            api.getBitcoinPrice()
+            delay(3000)
             api.getBitcoinPrice()
         }
     }

--- a/kommute/build.gradle
+++ b/kommute/build.gradle
@@ -4,10 +4,10 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
-        minSdk 30
+        minSdk 21
         targetSdk 32
     }
 
@@ -42,7 +42,7 @@ ext {
 }
 
 dependencies {
-    implementation "androidx.core:core-ktx:1.7.0"
+    implementation "androidx.core:core-ktx:1.9.0"
     implementation "androidx.activity:activity-compose:1.4.0"
 
     implementation "com.squareup.okhttp3:logging-interceptor:4.9.3"

--- a/kommute/src/main/res/values/strings.xml
+++ b/kommute/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="details_request_body_empty">Empty Request Body</string>
     <string name="details_headers_empty">Empty Headers</string>
     <string name="details_state_error">Couldn\'t find request</string>
-    <string name="notification_name">Network Sniffer</string>
+    <string name="notification_name">Kommute</string>
     <string name="notification_text">Monitor your apps commute</string>
-    <string name="notification_channel_description">Notification for the Network Sniffer</string>
+    <string name="notification_channel_description">Notification for Kommute</string>
 </resources>


### PR DESCRIPTION
Lowers the minSdk of Kommute to 21, to enable usage in apps with lower minSdk.
Compat libraries for the notification classes are used. Bubbles are only shown on Android 10 and above.