### PR TITLE
Implement separate image loader to fix logging duplicate calls

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
     <codeStyleSettings language="XML">
       <option name="FORCE_REARRANGE_MODE" value="1" />
       <indentOptions>
@@ -112,6 +115,9 @@
           </section>
         </rules>
       </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
     <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default (1)" />
   </state>
 </component>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.8.10" />
+  </component>
+</project>

--- a/kommute/build.gradle
+++ b/kommute/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
     implementation libs.okhttp
     implementation libs.coil
+    implementation libs.coil.gif
 
     implementation libs.androidx.compose.compiler
     implementation libs.androidx.compose.ui

--- a/kommute/src/main/java/com/sebastianneubauer/kommute/details/navigation/DetailsDestination.kt
+++ b/kommute/src/main/java/com/sebastianneubauer/kommute/details/navigation/DetailsDestination.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import coil.ImageLoader
 import com.sebastianneubauer.kommute.details.DetailsUi
 import com.sebastianneubauer.kommute.details.DetailsViewModel
 import com.sebastianneubauer.kommute.navigation.NavigationDestination
@@ -15,6 +16,7 @@ internal object DetailsDestination : NavigationDestination {
 
 internal fun NavGraphBuilder.detailsGraph(
     viewModelFactory: DetailsViewModel.Factory,
+    imageLoader: ImageLoader,
     onBackClick: () -> Unit
 ) {
     composable(
@@ -26,6 +28,6 @@ internal fun NavGraphBuilder.detailsGraph(
             onBackClick()
         }
 
-        DetailsUi(requestId!!, viewModelFactory, onBackClick)
+        DetailsUi(requestId!!, viewModelFactory, imageLoader, onBackClick)
     }
 }

--- a/kommute/src/main/java/com/sebastianneubauer/kommute/ui/KommuteActivity.kt
+++ b/kommute/src/main/java/com/sebastianneubauer/kommute/ui/KommuteActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
+import coil.ImageLoader
 import com.sebastianneubauer.kommute.Kommute
 import com.sebastianneubauer.kommute.details.DetailsViewModel
 import com.sebastianneubauer.kommute.details.navigation.DetailsDestination
@@ -13,6 +14,7 @@ import com.sebastianneubauer.kommute.feed.FeedViewModel
 import com.sebastianneubauer.kommute.feed.navigation.FeedDestination
 import com.sebastianneubauer.kommute.feed.navigation.feedGraph
 import com.sebastianneubauer.kommute.util.LocalDateTimeFormatter
+import com.sebastianneubauer.kommute.util.localImageLoader
 
 internal class KommuteActivity : ComponentActivity() {
 
@@ -20,9 +22,11 @@ internal class KommuteActivity : ComponentActivity() {
     private val dateTimeFormatter = LocalDateTimeFormatter()
     private val feedViewModelFactory = FeedViewModel.Factory(repository, dateTimeFormatter)
     private val detailsViewModelFactory = DetailsViewModel.Factory(repository)
+    private lateinit var imageLoader: ImageLoader
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        imageLoader = localImageLoader(applicationContext)
 
         setContent {
             val navController = rememberNavController()
@@ -37,6 +41,7 @@ internal class KommuteActivity : ComponentActivity() {
                 )
                 detailsGraph(
                     viewModelFactory = detailsViewModelFactory,
+                    imageLoader = imageLoader,
                     onBackClick = { navController.popBackStack() }
                 )
             }

--- a/kommute/src/main/java/com/sebastianneubauer/kommute/util/LocalImageLoader.kt
+++ b/kommute/src/main/java/com/sebastianneubauer/kommute/util/LocalImageLoader.kt
@@ -1,0 +1,22 @@
+package com.sebastianneubauer.kommute.util
+
+import android.content.Context
+import android.os.Build
+import coil.ImageLoader
+import coil.decode.GifDecoder
+import coil.decode.ImageDecoderDecoder
+
+/**
+ * An ImageLoader to display images and gifs in Kommute.
+ * This ImageLoader instance is separate from the consumer app one, to avoid
+ * logging calls to the same gif whenever it is shown in Kommute.
+ */
+internal fun localImageLoader(context: Context) = ImageLoader.Builder(context)
+    .components {
+        if (Build.VERSION.SDK_INT >= 28) {
+            add(ImageDecoderDecoder.Factory())
+        } else {
+            add(GifDecoder.Factory())
+        }
+    }
+    .build()


### PR DESCRIPTION
If the consumer app provides an ImageLoader through the app wide ImageLoaderFactory, then Kommutes Coil will use this ImageLoader implicitly. This causes that showing a gif in Kommute logs another call to the same gif link.

To avoid this behaviour, Kommute explicitly uses a separate ImageLoader instance now.